### PR TITLE
Fix wrong Content-Length

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,7 @@ else ()
   set (CMAKE_C_STANDARD 99)
 endif ()
 
-set(VERSION 0.2.0)
+set(VERSION 0.2.1)
 
 option(DEBUG              "compile with debug symbol"    OFF)
 option(BUNDLE_CIVETWEB    "bundle civetweb with uts-server"    OFF)

--- a/ChangeLog.rst
+++ b/ChangeLog.rst
@@ -1,6 +1,11 @@
 Changelogs
 ==========
 
+0.2.1
+-----
+
+* [fix ] fix compilation for newer GCC (>10.2) (global variable definition issue 
+
 0.2.0
 -----
 

--- a/README.rst
+++ b/README.rst
@@ -27,6 +27,11 @@ Micro `RFC 3161 Time-Stamp <https://www.ietf.org/rfc/rfc3161.txt>`_ server writt
 
 ----
 
+Demo
+----
+
+A demo is accessible here: https://uts-server.kakwalab.ovh/
+
 License
 -------
 

--- a/inc/http.h
+++ b/inc/http.h
@@ -10,7 +10,6 @@ int http_server_start(char *conffile, char *conf_wd, bool stdout_dbg);
 #define STATIC_PAGE                                                               \
     "HTTP/1.1 200 OK\r\n"                                                         \
     "Content-Type: text/html\r\n"                                                 \
-    "Content-Length: 2774\r\n"                                                    \
     "\r\n"                                                                        \
     "<html>"                                                                      \
     "<head>"                                                                      \

--- a/inc/utils.h
+++ b/inc/utils.h
@@ -18,7 +18,3 @@ int set_params(rfc3161_context *ct, char *conf_file, char *conf_wd);
 static char *rand_string(char *str, size_t size);
 void free_uts_context(rfc3161_context *ct);
 const char *null_undef(const char *in);
-
-// some global variable to handle signals
-int g_uts_sig_up;
-int g_uts_sig;

--- a/src/lib/http.c
+++ b/src/lib/http.c
@@ -9,6 +9,9 @@
 #include <time.h>
 #include <unistd.h>
 
+extern int g_uts_sig_up;
+extern int g_uts_sig;
+
 static char *rand_string(char *str, size_t size) {
     const char charset[] = "1234567890ABCDEF";
     if (size) {

--- a/src/lib/rfc3161.c
+++ b/src/lib/rfc3161.c
@@ -269,7 +269,7 @@ end:
         BN_free(serial_bn);
     } else {
         serial_hex = calloc(SERIAL_ID_SIZE, sizeof(char));
-        strncpy(serial_hex, " NO ID   ", SERIAL_ID_SIZE + 2);
+        strncpy(serial_hex, " NO ID   ", SERIAL_ID_SIZE + 4);
     }
 #endif
 #ifdef OPENSSL_API_1_0

--- a/src/lib/utils.c
+++ b/src/lib/utils.c
@@ -12,6 +12,10 @@
 #include <syslog.h>
 #include <unistd.h>
 
+// some global variable to handle signals
+int g_uts_sig_up;
+int g_uts_sig;
+
 static void signal_handler_general(int sig_num) {
     g_uts_sig = sig_num;
 }


### PR DESCRIPTION
Hey!

The static page sets Content-Length to a wrong size resulting in endless loops or errors when requesting.

Based on https://github.com/nicholasamorim/dockerfile-uts-server i'm running uts-server in a kubernetes-cluster and k8s health check fails with this content-length bug.

I suggest just removing Content-Length, it is not required at all (https://datatracker.ietf.org/doc/html/rfc2616#section-14.13 SHOULD)

```
# wget http://10.42.0.70:2020
--2021-05-20 14:51:06--  http://10.42.0.70:2020/
Connecting to 10.42.0.70:2020... connected.
HTTP request sent, awaiting response... 200 OK
Length: 2774 (2.7K) [text/html]
Saving to: ‘index.html’

index.html                                                           96%[==========================================================================================================================================================>       ]   2.61K  --.-KB/s    in 0s

2021-05-20 14:51:06 (542 MB/s) - Connection closed at byte 2670. Retrying.

--2021-05-20 14:51:07--  (try: 2)  http://10.42.0.70:2020/
Connecting to 10.42.0.70:2020... connected.
HTTP request sent, awaiting response... 200 OK
Length: 2774 (2.7K) [text/html]
```